### PR TITLE
Refactored editor panels.

### DIFF
--- a/src/components/CodeEditor.js
+++ b/src/components/CodeEditor.js
@@ -8,7 +8,7 @@ class CodeEditor extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      editorHeight: 850,
+      editorHeight: '90vh',
       editorWidth: 'auto'
     }
     this.onResize = this.onResize.bind(this);

--- a/src/components/ResultsEditor.js
+++ b/src/components/ResultsEditor.js
@@ -8,7 +8,7 @@ class ResultsEditor extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      editorHeight: 850,
+      editorHeight: '90vh',
       editorWidth: 'auto'
     }
     this.onResize = this.onResize.bind(this);

--- a/src/components/ResultsEditor.js
+++ b/src/components/ResultsEditor.js
@@ -33,15 +33,14 @@ class ResultsEditor extends Component {
         height={this.state.editorHeight}
         width={this.state.editorWidth}
         value={this.props.logs}
+        showGutter={false}
         editorProps={{ $blockScrolling: true }}
         cursorStart={0}
         showLineNumbers={false}
         readOnly={true}
         highlightActiveLine={false}
         setOptions={{
-          showLineNumbers: false,
-          enableBasicAutocompletion: false,
-          enableLiveAutocompletion: false
+          showLineNumbers: false
         }}
       />
     )


### PR DESCRIPTION
Removed gutter from results panel and changed the size of the editors (fits screen with 'Run Code' button).

TODO: Remove the entire results editor as a whole and replace it with a component that displays results with Material-UI components (cards?)