### PR TITLE
Added error handling for network connectivity issues.

### DIFF
--- a/src/App/App.js
+++ b/src/App/App.js
@@ -97,6 +97,16 @@ class App extends Component {
       }
 
       this.addToLog(result)
+    }).catch(error => {
+      this.setFinishedStatus()
+
+      let currentResults = this.state.results
+      currentResults.unshift('Code cannot be executed. Network connection to server cannot be established.\n')
+
+      this.setState({
+        ...this.state,
+        results: currentResults
+      })
     })
   }
 
@@ -124,8 +134,7 @@ class App extends Component {
 
     this.setState({
       ...this.state,
-      results: currentResults,
-      disabled: false
+      results: currentResults
     })
   }
 


### PR DESCRIPTION
If a network connection cannot be established to the backend server, the 'Run Code' button continues to be disabled and the user is not notified of the issue.

This issue has been fixed. When no network connection can be made, the error will appear on the logs and the 'Run Code' button will be re-enabled.